### PR TITLE
HivePlugins aren't intended to work with DataStreams

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -162,7 +162,6 @@
           <configuration>
             <cdapArtifacts>
               <parent>system:cdap-data-pipeline[4.2.0,9.0.0-SNAPSHOT)</parent>
-              <parent>system:cdap-data-streams[4.2.0,9.0.0-SNAPSHOT)</parent>
             </cdapArtifacts>
           </configuration>
           <executions>


### PR DESCRIPTION
HivePlugins aren't intended to work with DataStreams, because it is an Action plugin.
So, remove cdap-data-streams from parent artifacts.