### PR TITLE
PLUGIN-1294: upgrade org.apache.hive to 2.3.3 to fix CVE-2018-1282

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -86,8 +86,9 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <cdap.version>6.1.0-SNAPSHOT</cdap.version>
-    <hydrator.version>2.2.0-SNAPSHOT</hydrator.version>
+    <cdap.version>6.1.4</cdap.version>
+    <hydrator.version>2.2.0</hydrator.version>
+    <hive.version>2.3.3</hive.version>
   </properties>
 
   <dependencies>
@@ -118,12 +119,12 @@
     <dependency>
       <groupId>org.apache.hive</groupId>
       <artifactId>hive-jdbc</artifactId>
-      <version>1.1.0</version>
+      <version>${hive.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.hive</groupId>
       <artifactId>hive-exec</artifactId>
-      <version>1.1.0</version>
+      <version>${hive.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.hadoop</groupId>
@@ -177,7 +178,7 @@
           <version>1.1.0</version>
           <configuration>
             <cdapArtifacts>
-              <parent>system:cdap-data-pipeline[6.1.0-SNAPSHOT,7.0.0-SNAPSHOT)</parent>
+              <parent>system:cdap-data-pipeline[6.1.4,7.0.0-SNAPSHOT)</parent>
             </cdapArtifacts>
           </configuration>
           <executions>


### PR DESCRIPTION
Upgraded `org.apache.hive:hive-jdbc` & `org.apache.hive:hive-exec` from `1.1.0` to `2.3.3`.

Fixes vulnerability

[CVE-2018-1282](https://github.com/advisories/GHSA-jf2m-435m-mxw8)